### PR TITLE
Set default_realm

### DIFF
--- a/lib/Hooks/UserLoggedInEventListener.php
+++ b/lib/Hooks/UserLoggedInEventListener.php
@@ -261,6 +261,7 @@ class UserLoggedInEventListener implements IEventListener {
 			'share' => $share,
 			'root' => '',
 			'domain' => $domain,
+			'default_realm' => $domain,
 		];
 		$mount->setBackendOptions($backendOptions);
 		$mount->setApplicableUsers([$user->getUID()]);


### PR DESCRIPTION
This is used by the KerberosApacheAuth mechanism. I'm honestly not sure what is the difference between the default_realm and domain in KerberosApacheAuth and both default to WORKGROUP when not set.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>